### PR TITLE
Use AddressSanitizer when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "cargo-careful"
 version = "0.2.4"
 dependencies = [
+ "anyhow",
  "directories",
  "rustc-build-sysroot",
  "rustc_version",
+ "serde_json",
 ]
 
 [[package]]
@@ -79,10 +81,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.133"
+name = "itoa"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "libc"
+version = "0.2.134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "proc-macro2"
@@ -152,10 +160,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+
+[[package]]
+name = "serde_json"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/RalfJung/cargo-careful"
 description = "Execute Rust code carefully, with extra checking along the way"
 
 [dependencies]
+anyhow = "1.0.65"
 directories = "4"
 rustc_version = "0.4"
-rustc-build-sysroot = "0.4"
+rustc-build-sysroot = "0.4.0"
+serde_json = "1.0.87"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The first time you run `cargo careful`, it needs to run some setup steps, which 
 
 ## What does it do?
 
+### Assertions
+
 The most important thing `cargo careful` does is that it builds the standard library with debug
 assertions. The standard library already contains quite a few sanity checks that are enabled as
 debug assertions, but the usual rustup distrubtion compiles them all away to avoid run-time checks.
@@ -46,3 +48,21 @@ Here are some of the checks this enables:
 That said, there is a lot of Undefined Behavior that is *not* detected by `cargo careful`; check out
 [Miri](https://github.com/rust-lang/miri) if you want to be more exhaustively covered.
 The advantage of `cargo careful` over Miri is that it works on all code, supprts using arbitrary system and C FFI functions, and is much faster.
+
+### Sanitizing
+
+`cargo careful` can additionally build and run your program and standard library
+with a sanitizer. This feature is experimental and disabled by default, as
+the [underlying `rustc` feature](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
+doesn't play well with proc macros.
+
+To use a sanitizer, pass the command-line flag `-Zcareful-sanitizer=<your_sanitizer>` to `cargo careful`.
+The list of supported sanitizers and targets can be found
+[here](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html).
+If you pass `-Zcareful-sanitizer` without specifying a sanitizer, [`AddressSanitizer`](https://clang.llvm.org/docs/AddressSanitizer.html)
+will be used.
+
+By default, when using `AddressSanitizer`, `cargo careful` will disable memory leak checking by
+setting `ASAN_OPTIONS=detect_leaks=0` in your program's environment, as memory leaks are not
+usually a soundness or correctness issue. If you set the `ASAN_OPTIONS` environment variable
+yourself (to any value, including an empty string), that will override this behavior.

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
 /// Returns whether the given sanitizer is supported on this target.
 ///
 /// # Errors
-/// Returns `Err` if there was an error when geutting the list of supported sanitizers.
+/// Returns `Err` if there was an error when getting the list of supported sanitizers.
 pub fn sanitizer_supported(san: &str, target: &str) -> Result<bool> {
     // To get the list of supported sanitizers, we call `rustc --print target-spec-json`
     // and parse the output.


### PR DESCRIPTION
Compiles and runs the program and standard library with AddressSanitizer on targets that support it. This sanitizer ["is not expected to give false positive reports"](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer).