### PR TITLE
Add `-Coverflow-checks=on` to the list of 'careful flags'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ const CAREFUL_FLAGS: &[&str] = &[
     "-Zstrict-init-checks",
     "-Zextra-const-ub-checks",
     "-Cdebug-assertions=on",
+    "-Coverflow-checks=on",
 ];
 const STD_FEATURES: &[&str] = &["panic_unwind", "backtrace"];
 


### PR DESCRIPTION
I believe this mostly matters for if the stdlib will have these on, since normally it would be on for non-release builds of user code. This perhaps indicates a bug in the stdlib more than in the user's code, but I am not sure if that applies to 100% of the cases this could catch.