### PR TITLE
README: Recommend `--target` for sanitized builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ itself.
 ### Sanitizing
 
 `cargo careful` can additionally build and run your program and standard library
-with a sanitizer. This feature is experimental and disabled by default, as
-the [underlying `rustc` feature](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
-doesn't play well with proc macros.
+with a sanitizer. This feature is experimental and disabled by default. 
+
+The [underlying `rustc` feature](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
+doesn't play well with [procedural macros](https://doc.rust-lang.org/reference/procedural-macros.html).
+If you see error messages involving procedural macros during the build, they
+can sometimes be solved by specifying a target, e.g., `--target=x86_64-unknown-linux-gnu`.
 
 To use a sanitizer, pass the command-line flag `-Zcareful-sanitizer=<your_sanitizer>` to `cargo careful`.
 The list of supported sanitizers and targets can be found

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ with a sanitizer. This feature is experimental and disabled by default.
 The [underlying `rustc` feature](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
 doesn't play well with [procedural macros](https://doc.rust-lang.org/reference/procedural-macros.html).
 If you see error messages involving procedural macros during the build, they
-can sometimes be solved by specifying a target, e.g., `--target=x86_64-unknown-linux-gnu`.
+can sometimes be solved by specifying a target (which can be the same as the host),
+e.g., `--target=x86_64-unknown-linux-gnu`.
 
 To use a sanitizer, pass the command-line flag `-Zcareful-sanitizer=<your_sanitizer>` to `cargo careful`.
 The list of supported sanitizers and targets can be found


### PR DESCRIPTION
Recommended here:

- https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html
- https://github.com/japaric/rust-san

I got a build error on `proc-macro-hack`, but adding this flag fixed it for me!