### PR TITLE
reduce the range of nightlies we test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,8 @@ jobs:
       matrix:
         rust:
           - nightly
-          - nightly-2024-01-01
-          - nightly-2023-07-01
-          - nightly-2023-01-01
+          # Check a ~3 months old nightly as "oldest supported version"
+          - nightly-2023-10-01
         os:
           - ubuntu-latest
           - macos-latest
@@ -53,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64.0
+          toolchain: 1.75.0
           components: rustfmt, clippy
       - name: rustfmt
         run: cargo fmt --check

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ pub fn get_rustflags() -> Vec<String> {
     // As fallback, ask `cargo config`.
     // FIXME: This does not take into account `target.rustflags`.
     let mut cmd = cargo();
-    cmd.args(&["config", "build.rustflags", "--format=json-value"]);
+    cmd.args(["config", "build.rustflags", "--format=json-value"]);
     cmd.args(cargo_extra_flags());
     let output = cmd.output().expect("failed to run `cargo config`");
     if !output.status.success() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,6 +43,7 @@ pub fn exec(mut cmd: Command, verbose: Option<&str>) -> ! {
     // If exec returns, process setup has failed. This is the same error condition as the expect in
     // the non-Unix case.
     #[cfg(unix)]
+    #[allow(clippy::unnecessary_literal_unwrap)]
     {
         use std::os::unix::process::CommandExt;
         let error = cmd.exec();


### PR DESCRIPTION
also bump the version we use for clippy and fmt