### PR TITLE
update motivating example

### DIFF
--- a/test/tests/tests.rs
+++ b/test/tests/tests.rs
@@ -20,6 +20,18 @@ fn uninit_u8() {
     let _ = unsafe { std::mem::uninitialized::<u8>() };
 }
 
+// We cannot test `read` alignment checks since that will abort, not unwind.
+#[test]
+#[ignore]
+#[should_panic]
+fn read_unaligned() {
+    let arr = [1u8, 2, 3, 4];
+    for n in [0, 1] {
+        let val = unsafe { arr.as_ptr().add(n).cast::<u16>().read() };
+        println!("The value is {val}!");
+    }
+}
+
 #[test]
 #[should_panic]
 fn c_str() {


### PR DESCRIPTION
`cargo careful` is partially subsumed by the new std UB checks that are enabled in debug-assertion builds, but not entirely. So update the readme accordingly.

Fixes https://github.com/RalfJung/cargo-careful/issues/30