### PR TITLE
fix(darwin): ensure compatibility between --config and nextest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,8 @@ fn cargo_careful(args: env::Args) -> Result<()> {
             return Ok(());
         }
     };
+    // we need to do some compat work, as nextest does not support `--config`
+    let is_nextest = subcommand == "nextest";
 
     // Invoke cargo for the real work.
     let mut flags: Vec<OsString> = CAREFUL_FLAGS.iter().map(Into::into).collect();
@@ -402,9 +404,15 @@ fn cargo_careful(args: env::Args) -> Result<()> {
     // Apple-specific and will likely be ignored on other hosts.
     if target.contains("-darwin") {
         if let Some(path) = main_thread_checker_path()? {
-            cmd.arg("--config");
-            // TODO: Quote the path correctly according to toml rules
-            cmd.arg(format!("env.DYLD_INSERT_LIBRARIES={path:?}"));
+            if is_nextest {
+                // Nextest does not support `--config` yet, so we have to set the env var
+                // directly.
+                cmd.env("DYLD_INSERT_LIBRARIES", path);
+            } else {
+                cmd.arg("--config");
+                // TODO: Quote the path correctly according to toml rules
+                cmd.arg(format!("env.DYLD_INSERT_LIBRARIES={path:?}"));
+            }
         }
     }
 


### PR DESCRIPTION
## fix compatibility problem of `--config` and `nextest` on macos

pass env `DYLD_INSERT_LIBRARIES` instead of `--config` when the mode is nextest instead of test

fix https://github.com/RalfJung/cargo-careful/issues/35

## test

### before

![image](https://github.com/user-attachments/assets/9581f467-e5d4-4d2c-b1ec-14be9abdf787)

### after 

![image](https://github.com/user-attachments/assets/332e15a1-4beb-4cc0-8e30-e52f31f249f3)

